### PR TITLE
67 bff swagger page

### DIFF
--- a/bff/src/Controllers/UserController.cs
+++ b/bff/src/Controllers/UserController.cs
@@ -135,7 +135,7 @@ namespace NSW.Bff.Controllers
 		}
 
 
-		[Route("logout")]
+		[HttpGet("logout")]
 		public IActionResult Logout()
 		{
 			return SignOut("cookies", "oidc");

--- a/bff/src/NSW_BFF.csproj
+++ b/bff/src/NSW_BFF.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.11.1" />
     <PackageReference Include="ProxyKit" Version="2.3.4" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
adds a swagger page for "public" routes that "bypass" authentication by using a client token to get data from the API.  These routes cover data that would normally be made public by the site anyway. 

The swagger page allows easier UI client adoption of the routes
